### PR TITLE
fix: return full paths which matches moov-io/go-sftp behavior

### DIFF
--- a/client.go
+++ b/client.go
@@ -275,7 +275,7 @@ func (cc *client) ListFiles(dir string) ([]string, error) {
 	pattern := filepath.Clean(strings.TrimPrefix(dir, string(os.PathSeparator)))
 	switch {
 	case pattern == ".":
-		if dir == "" {
+		if dir == "" || dir == "/" {
 			pattern = "*"
 		} else {
 			pattern = filepath.Join(dir, "*")
@@ -294,7 +294,7 @@ func (cc *client) ListFiles(dir string) ([]string, error) {
 		}
 		matches, err := filepath.Match(pattern, path)
 		if matches && err == nil {
-			filenames = append(filenames, filepath.Base(path))
+			filenames = append(filenames, filepath.Join(dir, filepath.Base(path)))
 		}
 		return err
 	})

--- a/client_test.go
+++ b/client_test.go
@@ -76,20 +76,24 @@ func TestClient(t *testing.T) {
 		filenames, err := client.ListFiles(".")
 		require.NoError(t, err)
 		require.ElementsMatch(t, filenames, []string{"first.txt", "second.txt", "empty.txt"})
+
+		filenames, err = client.ListFiles("/")
+		require.NoError(t, err)
+		require.ElementsMatch(t, filenames, []string{"/first.txt", "/second.txt", "/empty.txt"})
 	})
 
 	t.Run("list subdir", func(t *testing.T) {
 		filenames, err := client.ListFiles("archive")
 		require.NoError(t, err)
-		require.ElementsMatch(t, filenames, []string{"old.txt", "empty2.txt"})
+		require.ElementsMatch(t, filenames, []string{"archive/old.txt", "archive/empty2.txt"})
 
 		filenames, err = client.ListFiles("/archive")
 		require.NoError(t, err)
-		require.ElementsMatch(t, filenames, []string{"old.txt", "empty2.txt"})
+		require.ElementsMatch(t, filenames, []string{"/archive/old.txt", "/archive/empty2.txt"})
 
 		filenames, err = client.ListFiles("/archive/")
 		require.NoError(t, err)
-		require.ElementsMatch(t, filenames, []string{"old.txt", "empty2.txt"})
+		require.ElementsMatch(t, filenames, []string{"/archive/old.txt", "/archive/empty2.txt"})
 	})
 
 	t.Run("walk", func(t *testing.T) {
@@ -99,7 +103,22 @@ func TestClient(t *testing.T) {
 			return nil
 		})
 		require.NoError(t, err)
-		require.ElementsMatch(t, found, []string{"first.txt", "second.txt", "empty.txt", "archive/old.txt", "archive/empty2.txt"})
+		require.ElementsMatch(t, found, []string{
+			"first.txt", "second.txt", "empty.txt",
+			"archive/old.txt", "archive/empty2.txt",
+		})
+	})
+
+	t.Run("walk subdir", func(t *testing.T) {
+		var found []string
+		err := client.Walk("/archive", func(path string, d fs.DirEntry, err error) error {
+			found = append(found, path)
+			return nil
+		})
+		require.NoError(t, err)
+		require.ElementsMatch(t, found, []string{
+			"/archive/old.txt", "/archive/empty2.txt",
+		})
 	})
 
 	require.NoError(t, client.Close())


### PR DESCRIPTION
Verified in https://github.com/moov-io/go-sftp/pull/154 