### PR TITLE
fix: allow Reader to stream larger files

### DIFF
--- a/client.go
+++ b/client.go
@@ -222,10 +222,10 @@ func (cc *client) Open(path string) (*File, error) {
 }
 
 // Reader will open the file at path and provide a reader to access its contents.
-// Callers need to close the returned Contents
+// Callers need to close the returned Contents.
 //
 // Callers should be aware that network errors while reading can occur since contents
-// are streamed from the FTP server. Having multiple open readers may not be supported.
+// are streamed from the FTP server. Having multiple open readers is not supported.
 func (cc *client) Reader(path string) (*File, error) {
 	cc.mu.Lock()
 	defer cc.mu.Unlock()

--- a/file.go
+++ b/file.go
@@ -32,13 +32,15 @@ func (f *File) Close() error {
 	if f == nil {
 		return nil
 	}
+	if f.Contents != nil {
+		if err := f.Contents.Close(); err != nil {
+			return err
+		}
+	}
 	if f.cleanup != nil {
 		if err := f.cleanup(); err != nil {
 			return err
 		}
-	}
-	if f.Contents != nil {
-		return f.Contents.Close()
 	}
 	return nil
 }

--- a/file.go
+++ b/file.go
@@ -22,6 +22,8 @@ type File struct {
 	ModTime time.Time
 
 	fileinfo fs.FileInfo
+
+	cleanup func() error
 }
 
 var _ fs.File = (&File{})
@@ -29,6 +31,11 @@ var _ fs.File = (&File{})
 func (f *File) Close() error {
 	if f == nil {
 		return nil
+	}
+	if f.cleanup != nil {
+		if err := f.cleanup(); err != nil {
+			return err
+		}
 	}
 	if f.Contents != nil {
 		return f.Contents.Close()


### PR DESCRIPTION
The FTP library we use only allows one action at a time, which we control fairly well with mutexes. When streaming files that are larger than a buffer we're switching the ServerConn's action, which makes reading the next buffer of data hang. 