### PR TITLE
ci: run CodeQL only on master and PRs to master

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -13,6 +13,7 @@ permissions:
 
 jobs:
   CodeQL-Build:
+    if: ${{ !github.event.repository.private && !github.event.repository.archived }}
     permissions:
       actions: read
       contents: read

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -3,7 +3,9 @@ name: CodeQL Analysis
 
 on:
   push:
+    branches: [ master ]
   pull_request:
+    branches: [ master ]
   schedule:
     - cron: '15 10 * * 0'
   workflow_dispatch:

--- a/renovate.json
+++ b/renovate.json
@@ -13,5 +13,6 @@
       ],
       "automerge": true
     }
-  ]
+  ],
+  "platformAutomerge": true
 }


### PR DESCRIPTION
Master CodeQL is already green. Failures like [fincen#97964526027](https://github.com/moov-io/fincen/actions/runs/32897853503/job/97964526027) happen when CodeQL analyzes a feature-branch `push` and then the branch is deleted (`--delete-branch`) before SARIF upload can attach to that ref:

```
ref 'refs/heads/ci/skip-codeql-without-ghas' not found in this repository
```

Limit CodeQL to `master` pushes, PRs targeting `master`, schedule, and workflow_dispatch.