### PR TITLE
ci: skip code owners on GitHub Actions workflow files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,3 +8,5 @@ go.sum
 
 # GitHub Actions workflows have no owners so action-only PRs skip code-owner review.
 .github/workflows/**
+.github/workflows/*
+**/.github/workflows/*


### PR DESCRIPTION
CODEOWNERS `.github/workflows/**` does not match files directly in `.github/workflows/` on GitHub (last-match still falls through to `* @adamdecaf`, so workflow-only PRs still request review).

Add the same empty-owner rules already on fincen: `.github/workflows/*` and `**/.github/workflows/*`.